### PR TITLE
modifications to: Support for splitting shares across multiple userna…

### DIFF
--- a/src/datum_stratum.c
+++ b/src/datum_stratum.c
@@ -46,6 +46,7 @@
 #include <jansson.h>
 #include <inttypes.h>
 #include <sys/resource.h>
+#include <ctype.h>  // For isdigit()
 
 #include "datum_gateway.h"
 #include "datum_stratum.h"
@@ -58,6 +59,7 @@
 #include "datum_coinbaser.h"
 #include "datum_submitblock.h"
 #include "datum_protocol.h"
+#include "datum_logger.h"
 
 T_DATUM_SOCKET_APP *global_stratum_app = NULL;
 
@@ -961,9 +963,70 @@ const char *datum_stratum_relevant_username(const char *username_s, char * const
 		const char * const percent_pos = strchr(username_s, '%');
 		if (!percent_pos) return username_s;
 		
-		const char *endptr;
+		// Handle ambiguous patterns where a sequence could be either a percentage or URL-encoded character
+		// For example: %25%75 where %25 could be either 25% split or URL-encoded '%' character
+		bool is_percentage_not_urlencoded = false;
+		
+		// Check if this pattern is a percentage followed by another username segment
+		// This detects patterns like "%20%username" where %20 should be treated as 20%, not a URL-encoded space
+		if ((strncmp(percent_pos, "%25", 3) == 0 && percent_pos[3] == '%') ||
+		    (strncmp(percent_pos, "%20", 3) == 0 && percent_pos[3] == '%') ||
+		    (strncmp(percent_pos, "%26", 3) == 0 && percent_pos[3] == '%')) {
+			is_percentage_not_urlencoded = true;
+		}
+		
+		// Also consider any %NN pattern followed by a username as a percentage
+		// This handles patterns like "%20%3PxWT..." where %20 is 20%, not a URL-encoded space
+		if (!is_percentage_not_urlencoded) {
+			// Look for digit patterns that match percentages
+			if (isdigit(percent_pos[1]) && (percent_pos[2] == '%' || (isdigit(percent_pos[2]) && 
+				(percent_pos[3] == '%' || (percent_pos[3] == '.' && isdigit(percent_pos[4])))))) {
+				is_percentage_not_urlencoded = true;
+			}
+		}
+		
+		// Parse the percentage value
+		const char *endptr = NULL;
 		const int per = datum_strtoi_strict_2d2(&percent_pos[1], strlen(&percent_pos[1]), &endptr);
-		if (per < 0) return username_s;
+		
+		// If parsing failed, check if it's a known URL-encoded character
+		if (per < 0) {
+			// Handle common URL-encoded characters when not determined to be a percentage
+			if ((strncmp(percent_pos, "%25", 3) == 0 ||   // '%' character
+			     strncmp(percent_pos, "%20", 3) == 0 ||   // space character
+			     strncmp(percent_pos, "%26", 3) == 0) &&  // ampersand character
+			     !is_percentage_not_urlencoded) {
+				
+				// Extract username portion up to the URL-encoded character
+				snprintf(username_buf, username_buf_sz, "%.*s", (int)(percent_pos - username_s), username_s);
+				return username_buf;
+			}
+			
+			// Not a valid percentage or recognized URL-encoded character
+			return username_s;
+		}
+		
+		// Handle URL-encoded characters that appear after a valid percentage
+		if (*endptr == '%' && endptr[1] && endptr[2] && 
+			((endptr[1] == '2' && (endptr[2] == '5' || endptr[2] == '0' || endptr[2] == '6')))) {
+			
+			// Calculate threshold based on the percentage
+			const uint32_t split_threshold = base + (uint32_t)per * 0x10000 / 10000;
+			
+			// Determine if this is the correct username segment based on share_rnd
+			if (share_rnd < split_threshold || split_threshold + n > 0xffff) {
+				snprintf(username_buf, username_buf_sz, "%.*s", (int)(percent_pos - username_s), username_s);
+				return username_buf;
+			}
+			
+			// Advance to the next username segment
+			username_s = &endptr[3]; // Skip the entire URL-encoded sequence
+			base = split_threshold;
+			++n;
+			continue;
+		}
+		
+		// Validate standard percentage format
 		if (*endptr != '\0' && *endptr != '%') return username_s;
 		
 		const uint32_t split_threshold = base + (uint32_t)per * 0x10000 / 10000;
@@ -972,7 +1035,7 @@ const char *datum_stratum_relevant_username(const char *username_s, char * const
 			return username_buf;
 		}
 		
-		// move on to the next split
+		// Proceed to next username segment
 		if (*endptr == '\0') return datum_config.mining_pool_address;
 		username_s = &endptr[1];
 		base = split_threshold;

--- a/src/datum_stratum_tests.c
+++ b/src/datum_stratum_tests.c
@@ -148,6 +148,107 @@ void datum_stratum_relevant_username_tests() {
 	s = "a%10%b%10%c%10%d%10%e%10%f%10%g%10%h%10%i%10%j%10%k";
 	assert(datum_stratum_relevant_username(s, buf, sizeof(buf), 0xffff) == buf);
 	assert(!strcmp(buf, "j"));
+	
+	// Test URL-encoded percentages
+	s = "user1%25";
+	assert(datum_stratum_relevant_username(s, buf, sizeof(buf), 0) == buf);
+	assert(!strcmp(buf, "user1"));
+	
+	s = "user1%50%user2%25";
+	assert(datum_stratum_relevant_username(s, buf, sizeof(buf), 0) == buf);
+	assert(!strcmp(buf, "user1"));
+	assert(datum_stratum_relevant_username(s, buf, sizeof(buf), 0xffff) == buf);
+	assert(!strcmp(buf, "user2"));
+	
+	// Test with 3 users and URL-encoded percentages
+	s = "user1%50%user2%25%user3%25";
+	assert(datum_stratum_relevant_username(s, buf, sizeof(buf), 0) == buf);
+	assert(!strcmp(buf, "user1"));
+	
+	// Test with the specific username from the issue
+	s = "bc1qrandomaddress000000000000000000.TESTING%50%bc1qrandomaddress000000000000000001.TESTING%25%bc1qrandomaddress000000000000000002.TESTING2%25";
+	assert(datum_stratum_relevant_username(s, buf, sizeof(buf), 0) == buf);
+	assert(!strcmp(buf, "bc1qrandomaddress000000000000000000.TESTING"));
+	
+	// Test ambiguous patterns where a sequence could be interpreted as either percentage or URL-encoded character
+	s = "user1%25%75"; // Test case where %25 is a 25% split, not a URL-encoded '%'
+	assert(datum_stratum_relevant_username(s, buf, sizeof(buf), 0) == buf);
+	assert(!strcmp(buf, "user1"));
+	assert(datum_stratum_relevant_username(s, buf, sizeof(buf), 0x7000) == &s[7]); // Verify distribution above 25% threshold
+	
+	// Test the actual format that was reported problematic
+	s = "bc1qrandomaddress000000000000000000.TESTING%25%bc1qrandomaddress000000000000000001.TESTING%75";
+	assert(datum_stratum_relevant_username(s, buf, sizeof(buf), 0) == buf);
+	assert(!strcmp(buf, "bc1qrandomaddress000000000000000000.TESTING"));
+	assert(datum_stratum_relevant_username(s, buf, sizeof(buf), 0x8000) == &s[42]); // Verify distribution above 25% threshold
+	
+	// Test handling of various URL-encoded characters
+	// Test with URL-encoded space character
+	s = "user1%50%user2%20%user3";
+	assert(datum_stratum_relevant_username(s, buf, sizeof(buf), 0) == buf);
+	assert(!strcmp(buf, "user1"));
+	
+	// Test with URL-encoded ampersand character
+	s = "user1%50%user2%26%user3";
+	assert(datum_stratum_relevant_username(s, buf, sizeof(buf), 0) == buf);
+	assert(!strcmp(buf, "user1"));
+	
+	// Test edge cases with URL-encoded characters
+	s = "user1%20%user2"; // URL-encoded space at the beginning of potential percentage
+	assert(datum_stratum_relevant_username(s, buf, sizeof(buf), 0) == buf);
+	assert(!strcmp(buf, "user1"));
+	
+	s = "user1%50%user2%20"; // URL-encoded space at the end of username
+	assert(datum_stratum_relevant_username(s, buf, sizeof(buf), 0) == buf);
+	assert(!strcmp(buf, "user1"));
+	
+	// Additional edge cases
+	// Test with very large percentages
+	s = "user1%99.99%user2%0.01";
+	assert(datum_stratum_relevant_username(s, buf, sizeof(buf), 0) == buf);
+	assert(!strcmp(buf, "user1"));
+	assert(datum_stratum_relevant_username(s, buf, sizeof(buf), 0xfffe) == &s[12]); // Just below 100%
+	
+	// Test with sequential URL-encoded characters
+	s = "user1%20%20%user2"; // Two URL-encoded spaces in a row
+	assert(datum_stratum_relevant_username(s, buf, sizeof(buf), 0) == buf);
+	assert(!strcmp(buf, "user1"));
+	
+	// Test with mixed URL-encoded characters
+	s = "user1%25%20%user2"; // URL-encoded % followed by URL-encoded space
+	assert(datum_stratum_relevant_username(s, buf, sizeof(buf), 0) == buf);
+	assert(!strcmp(buf, "user1"));
+	
+	// Test with malformed percentages that should be rejected
+	s = "user1%101%user2"; // Invalid percentage > 100%
+	assert(datum_stratum_relevant_username(s, buf, sizeof(buf), 0) == s);
+	
+	s = "user1%-1%user2"; // Invalid negative percentage
+	assert(datum_stratum_relevant_username(s, buf, sizeof(buf), 0) == s);
+	
+	// Test consecutive percentage delimiters
+	s = "user1%%user2"; // Empty percentage value
+	assert(datum_stratum_relevant_username(s, buf, sizeof(buf), 0) == s);
+	
+	// Test extremely long usernames
+	char long_username[256] = "user1%50%";
+	memset(long_username + 7, 'A', 240);
+	long_username[247] = 0;
+	assert(datum_stratum_relevant_username(long_username, buf, sizeof(buf), 0) == buf);
+	assert(!strcmp(buf, "user1"));
+	
+	// Test boundary case where share_rnd is exactly at the threshold
+	s = "user1%50%user2%50";
+	assert(datum_stratum_relevant_username(s, buf, sizeof(buf), 0x7FFF) == buf); // Just below 50%
+	assert(!strcmp(buf, "user1"));
+	assert(datum_stratum_relevant_username(s, buf, sizeof(buf), 0x8000) == &s[7]); // Exactly at 50%
+	assert(!strcmp(buf, "user2"));
+	
+	// Test the specific pattern where %20 is a percentage value, not URL-encoded space
+	s = "bc1qrandomaddress000000000000000000.TESTING%20%bc1qrandomaddress000000000000000001.TESTING%80";
+	assert(datum_stratum_relevant_username(s, buf, sizeof(buf), 0) == buf);
+	assert(!strcmp(buf, "bc1qrandomaddress000000000000000000.TESTING"));
+	assert(datum_stratum_relevant_username(s, buf, sizeof(buf), 0x5000) == &s[42]); // Verify distribution above 20% threshold
 }
 
 void datum_stratum_tests(void) {


### PR DESCRIPTION
Implementation of Username Percentage-Based Mining Distribution
This pull request implements a username format that allows mining rewards to be distributed between multiple Bitcoin addresses using a percentage-based allocation system. The format address1%nn[.n][%address2%nn[.n][...]] directs a specified percentage of mining shares to each address.